### PR TITLE
14/create zbyte and zword data structures

### DIFF
--- a/tests/data_structures_test.py
+++ b/tests/data_structures_test.py
@@ -1,0 +1,284 @@
+import pytest
+
+from zfun import ZByte, ZWord, ZMachineIllegalOperation
+
+
+def test_instantiating_zbyte():
+    zb = ZByte(bytes.fromhex('12'))
+    assert zb.bytes == b'\x12', 'Instantiate ZByte from bytes'
+
+    zb = ZByte(memoryview(bytes.fromhex('42')))
+    assert zb.bytes == b'\x42', 'Instantiate ZByte from memoryview'
+
+    zb = ZByte.from_int(-1)
+    assert zb.bytes == b'\xff', 'Instantiate ZByte from int'
+
+    zb = ZByte.from_unsigned_int(0xf0)
+    assert zb.bytes == b'\xf0', 'Instantiate ZByte from unsigned int'
+
+    with pytest.raises(TypeError):
+        ZByte(22)
+
+    with pytest.raises(ValueError):
+        ZByte(b'\x12\x34')
+
+    with pytest.raises(ValueError):
+        ZByte(b'')
+
+    with pytest.raises(ValueError):
+        ZByte.from_int(-129)
+
+    with pytest.raises(ValueError):
+        ZByte.from_int(128)
+
+    with pytest.raises(ValueError):
+        ZByte.from_unsigned_int(-1)
+
+    with pytest.raises(ValueError):
+        ZByte.from_unsigned_int(256)
+
+
+def test_zbyte_to_zbyte_math():
+    zb = ZByte.from_int(0) + ZByte.from_int(12)
+    assert zb.bytes == b'\x0c', 'ZByte + ZByte'
+
+    zb = ZByte.from_int(0) - ZByte.from_int(1)
+    assert zb.bytes == b'\xff', 'ZByte - ZByte'
+
+    zb = ZByte.from_int(-128) - ZByte.from_int(1)
+    assert zb.bytes == b'\x7f', 'Zbyte arithmetic truncation'
+
+    zb = ZByte.from_int(-2) * ZByte.from_int(8)
+    assert zb.int == -16, 'ZByte * ZByte'
+
+    zb = ZByte.from_int(127) * ZByte.from_int(127)
+    assert zb.bytes == b'\x01', 'ZByte multiplication truncation'
+
+    zb = ZByte.from_int(3) // ZByte.from_int(2)
+    assert zb.bytes == b'\x01', 'ZByte integer division'
+
+    with pytest.raises(ZMachineIllegalOperation, match='Divide by zero'):
+        ZByte.from_int(45) // ZByte.from_int(0)
+
+    with pytest.raises(ZMachineIllegalOperation):
+        zb.from_int(4) / zb.from_int(8)
+
+    zb = ZByte(b'\x01').inc()
+    assert zb.bytes == b'\x02'
+
+    zb = ZByte(b'\xff').inc()
+    assert zb.bytes == b'\x00', 'Rollover on increment'
+
+    zb = ZByte.from_int(0).dec()
+    assert zb.int == -1
+
+    zb = ZByte(b'\x00').dec()
+    assert zb.bytes == b'\xff', 'Rollover on decrement'
+
+
+def test_zbyte_bitwise_operations():
+    zb = ZByte.from_unsigned_int(0b1010_1010) << 1
+    assert zb.unsigned_int == 0b0101_0100
+
+    zb = ZByte.from_unsigned_int(0b0000_1111) << 4
+    assert zb.unsigned_int == 0b1111_0000
+
+    zb = ZByte.from_unsigned_int(0b1111_0000) >> 4
+    assert zb.unsigned_int == 0b0000_1111
+
+    zb = ZByte.from_unsigned_int(0b0001_0000) >> 1
+    assert zb.unsigned_int == 0b0000_1000
+
+    zb = ZByte.from_unsigned_int(0b1111_1111) & 0b0101_0101
+    assert zb.bytes == b'\x55'
+
+    zb = ZByte.from_unsigned_int(0b1111_0000) | 0b0000_1111
+    assert zb.bytes == b'\xff'
+
+    zb = ~ZByte.from_unsigned_int(0b0101_0101)
+    assert zb.unsigned_int == 0b1010_1010
+
+    zb = ~ZByte.from_unsigned_int(0b0000_1111)
+    assert zb.unsigned_int == 0b1111_0000
+
+    zb = ZByte.from_unsigned_int(0b1010_1100)
+    assert zb.is_bit_set(7) is True
+    assert zb.is_bit_set(0) is False
+    assert zb.is_bit_set(3) is True
+    assert zb.is_bit_clear(7) is False
+    assert zb.is_bit_clear(0) is True
+    assert zb.is_bit_clear(3) is False
+
+
+def test_zbyte_read_and_write_memory(zork1_v3_data: memoryview):
+    zb = ZByte.read(zork1_v3_data, 0)
+    assert zb.int == 3
+
+    ZByte.from_int(42).write(zork1_v3_data, 0)
+    assert zork1_v3_data[0] == 42
+
+
+def test_zbyte_to_zword_math():
+    zw = ZByte.from_int(0) + ZWord.from_int(256)
+    assert zw.bytes == b'\x01\x00', 'ZByte + ZWord'
+
+    zw = ZByte.from_int(0) - ZWord.from_int(129)
+    assert zw.int == -129, 'ZByte - ZWord'
+
+    zw = ZByte.from_int(-2) * ZWord.from_int(128)
+    assert zw.int == -256, 'ZByte * ZWord'
+
+    zw = ZByte.from_int(126) // ZWord.from_int(2)
+    assert zw.int == 63, 'ZByte/ZWord integer division'
+
+    with pytest.raises(ZMachineIllegalOperation, match='Divide by zero'):
+        ZByte.from_int(45) // ZWord.from_int(0)
+
+    with pytest.raises(ZMachineIllegalOperation):
+        ZByte.from_int(4) / ZWord.from_int(8)
+
+
+def test_instantiate_zword():
+    zw = ZWord(bytes.fromhex('1234'))
+    assert zw.bytes == b'\x12\x34', 'Instantiate ZWord from bytes'
+
+    zw = ZWord(memoryview(bytes.fromhex('4242')))
+    assert zw.bytes == b'\x42\x42', 'Instantiate ZWord from memoryview'
+
+    zw = ZWord.from_int(-1)
+    assert zw.bytes == b'\xff\xff', 'Instantiate ZWord from int'
+
+    zw = ZWord.from_unsigned_int(0xf0f0)
+    assert zw.bytes == b'\xf0\xf0', 'Instantiate ZWord from unsigned int'
+
+    with pytest.raises(TypeError):
+        ZWord(22)
+
+    with pytest.raises(ValueError):
+        ZWord(b'\x12\x34\x69')
+
+    with pytest.raises(ValueError):
+        ZWord(b'\x12')
+
+    with pytest.raises(ValueError):
+        ZWord(b'')
+
+    with pytest.raises(ValueError):
+        ZWord.from_int(-32769)
+
+    with pytest.raises(ValueError):
+        ZWord.from_int(32768)
+
+    with pytest.raises(ValueError):
+        ZWord.from_unsigned_int(-1)
+
+    with pytest.raises(ValueError):
+        ZWord.from_unsigned_int(65536)
+
+
+def test_zword_zword_math():
+    zw = ZWord.from_int(0) + ZWord.from_int(512)
+    assert zw.bytes == b'\x02\x00', 'ZWord + ZWord'
+
+    zw = ZWord.from_int(0) - ZWord.from_int(1)
+    assert zw.bytes == b'\xff\xff', 'ZWord - ZWord'
+
+    zw = ZWord.from_int(-32768) - ZWord.from_int(1)
+    assert zw.bytes == b'\x7f\xff', 'ZWord arithmetic truncation'
+
+    zw = ZWord.from_int(-2) * ZWord.from_int(8)
+    assert zw.int == -16, 'ZWord * ZWord'
+
+    zw = ZWord.from_int(32767) * ZWord.from_int(32767)
+    assert zw.bytes == b'\x00\x01', 'ZWord multiplication truncation'
+
+    zw = ZWord.from_int(3) // ZWord.from_int(2)
+    assert zw.bytes == b'\x00\x01', 'ZWord integer division'
+
+    with pytest.raises(ZMachineIllegalOperation, match='Divide by zero'):
+        ZWord.from_int(45) // ZWord.from_int(0)
+
+    with pytest.raises(ZMachineIllegalOperation):
+        ZWord.from_int(4) / ZWord.from_int(8)
+
+    zw = ZWord(b'\x00\x01').inc()
+    assert zw.bytes == b'\x00\x02'
+
+    zw = ZWord(b'\xff\xfe').inc()
+    assert zw.bytes == b'\xff\xff'
+
+    zw = ZWord(b'\xff\xff').inc()
+    assert zw.bytes == b'\x00\x00', 'Rollover on increment'
+
+    zw = ZWord.from_int(500).dec()
+    assert zw.int == 499
+
+    zw = ZWord(b'\xff\xff').dec()
+    assert zw.bytes == b'\xff\xfe'
+
+    zw = ZWord(b'\x00\x00').dec()
+    assert zw.bytes == b'\xff\xff', 'Rollover on decrement'
+
+
+def test_zword_bitwise_operations():
+    zb = ZWord.from_unsigned_int(0b1010_1010_1010_1010) << 1
+    assert zb.unsigned_int == 0b0101_0101_0101_0100
+
+    zb = ZWord.from_unsigned_int(0b0000_1111_0000_1111) << 4
+    assert zb.unsigned_int == 0b1111_0000_1111_0000
+
+    zb = ZWord.from_unsigned_int(0b0000_1111_1111_0000) >> 4
+    assert zb.unsigned_int == 0b0000_0000_1111_1111
+
+    zb = ZWord.from_unsigned_int(0b0001_0000) >> 1
+    assert zb.unsigned_int == 0b0000_1000
+
+    zb = ZWord.from_unsigned_int(0b1111_1111) & 0b0101_0101
+    assert zb.unsigned_int == 0b0101_0101
+
+    zb = ZWord.from_unsigned_int(0b1111_0000) | 0b0000_1111
+    assert zb.bytes == b'\x00\xff'
+
+    zb = ~ZWord.from_unsigned_int(0b0101_0101)
+    assert zb.unsigned_int == 0b1111_1111_1010_1010
+
+    zb = ~ZWord.from_unsigned_int(0b0000_1111)
+    assert zb.unsigned_int == 0b1111_1111_1111_0000
+
+    zb = ZWord.from_unsigned_int(0b1111_0000_1111_0000)
+    assert zb.is_bit_set(15) is True
+    assert zb.is_bit_set(0) is False
+    assert zb.is_bit_set(4) is True
+    assert zb.is_bit_clear(15) is False
+    assert zb.is_bit_clear(0) is True
+    assert zb.is_bit_clear(4) is False
+
+
+def test_zword_read_and_write_memory(zork1_v3_data: memoryview):
+    zw = ZWord.read(zork1_v3_data, 6)
+    assert zw.unsigned_int == 0x4f05
+
+    ZWord.from_unsigned_int(0x4269).write(zork1_v3_data, 6)
+    assert zork1_v3_data[6:8] == b'\x42\x69'
+
+
+def test_zword_to_zbyte_math():
+    zw = ZWord.from_int(129) + ZByte.from_int(127)
+    assert zw.bytes == b'\x01\x00', 'ZWord + ZByte'
+
+    zw = ZWord.from_int(0) - ZByte.from_int(127)
+    assert zw.int == -127, 'ZWord - ZByte'
+
+    zw = ZWord.from_int(-4) * ZByte.from_int(64)
+    assert zw.int == -256, 'ZWord * ZByte'
+
+    zw = ZWord.from_int(126) // ZByte.from_int(2)
+    assert zw.int == 63, 'ZWord/ZByte integer division'
+
+    with pytest.raises(ZMachineIllegalOperation, match='Divide by zero'):
+        ZWord.from_int(45) // ZByte.from_int(0)
+
+    with pytest.raises(ZMachineIllegalOperation):
+        ZWord.from_int(4) / ZByte.from_int(8)
+
+

--- a/zfun/__init__.py
+++ b/zfun/__init__.py
@@ -1,3 +1,4 @@
+from .data_structures import ZByte, ZWord
 from .dictionary import ZMachineDictionary
 from .header import get_header, read_header, ZCodeHeader, StatusLineType
 from .input import ZMachineInput
@@ -13,6 +14,7 @@ from .exc import UnsupportedVersionError, ZMachineIllegalOperation
 
 
 __all__ = [
+    'ZByte', 'ZWord',
     'ZMachineDictionary',
     'get_header', 'read_header', 'ZCodeHeader', 'StatusLineType',
     'ZMachineInput',

--- a/zfun/data_structures.py
+++ b/zfun/data_structures.py
@@ -1,0 +1,401 @@
+from abc import ABC, abstractmethod
+from typing import Union
+
+from .exc import ZMachineIllegalOperation
+
+
+class ZData(ABC):
+
+    def __init__(self, value: bytes):
+        self._value: bytes = value
+
+    def __repr__(self):
+        return f'<{type(self).__name__} {self.__str__()}>'
+
+    def __str__(self):
+        return f'0x{self._value.hex()}'
+
+    def __len__(self):
+        return len(self._value)
+
+    @abstractmethod
+    def __add__(self, other):
+        pass
+
+    @abstractmethod
+    def __sub__(self, other):
+        pass
+
+    @abstractmethod
+    def __mul__(self, other):
+        pass
+
+    @abstractmethod
+    def __floordiv__(self, other):
+        pass
+
+    @abstractmethod
+    def __lshift__(self, other):
+        pass
+
+    @abstractmethod
+    def __rshift__(self, other):
+        pass
+
+    @abstractmethod
+    def __and__(self, other):
+        pass
+
+    @abstractmethod
+    def __or__(self, other):
+        pass
+
+    @abstractmethod
+    def __invert__(self):
+        pass
+
+    def __truediv__(self, other):
+        raise ZMachineIllegalOperation('Can not true-divide ZData')
+
+    @abstractmethod
+    def write(self, memory: memoryview, address: int):
+        """ Write ZData to memory at the provided address.
+
+        :param memory: Memory to write to
+        :param address: Address in memory to write to
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def read(memory: Union[bytes, memoryview], address: int):
+        """ Read ZData from memory at the provided address.
+
+        :param memory: Memory to read from
+        :param address: Address to read from
+        :return: ZData of memory at given address.
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def from_int(value: int):
+        """ Return ZData from a signed int
+
+        :param value: Int value to convert to ZData
+        :return:
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def from_unsigned_int(value: int):
+        """ Return ZData from an unsigned int
+
+        :param value: Unsigned int value to convert to ZData
+        :return:
+        """
+        pass
+
+    @property
+    def bytes(self) -> bytes:
+        """ Data value as a Python byte string"""
+        return self._value
+
+    @property
+    def int(self) -> int:
+        """ Value of data as a signed integer """
+        return int.from_bytes(self._value, 'big', signed=True)
+
+    @property
+    def unsigned_int(self) -> int:
+        """ Value of data as an unsigned integer """
+        return int.from_bytes(self._value, 'big', signed=False)
+
+    @abstractmethod
+    def inc(self, amount: int = 1):
+        """ Increment the value (unsigned addition) by the specified amount.
+
+        :return: New ZData with incremented value
+        """
+        pass
+
+    @abstractmethod
+    def dec(self, amount: int = 1):
+        """ Decrement the value (unsigned subtraction) by the specified amount.
+
+        :return: New ZData with decremented value
+        """
+        pass
+
+    @abstractmethod
+    def is_bit_set(self, bit_number: int) -> bool:
+        """ Test if the specified bit number is set.
+
+        :param bit_number: Bit number to test
+        :return: True if the bit is 1
+        """
+        pass
+
+    def is_bit_clear(self, bit_number: int) -> bool:
+        """ Test if the specified bit number is clear.
+
+        :param bit_number: Bit number to test
+        :return: True if the bit is 0
+        """
+        return not self.is_bit_set(bit_number)
+
+
+class ZByte(ZData):
+
+    def __init__(self, value: Union[bytes, memoryview]):
+        if type(value) == memoryview:
+            value = bytes(value)
+        elif type(value) != bytes:
+            raise TypeError('ZByte value can only be set with bytes or memoryview')
+
+        if len(value) != 1:
+            raise TypeError('only one byte can be assigned to a ZByte')
+
+        super().__init__(value)
+
+    def _trunc_int(self, calc_size: int, res_size: int, value: int) -> bytes:
+        bytes_val = value.to_bytes(calc_size, 'big', signed=True)
+        return bytes_val[calc_size-res_size:]
+
+    def __add__(self, other):
+        if not issubclass(ZData, other):
+            raise TypeError('can only add ZData types')
+
+        value = self.int + other.int
+        if type(other) == ZWord:
+            return ZWord(self._trunc_int(3, 2, value))
+        elif type(other) == ZByte:
+            return ZByte(self._trunc_int(2, 1, value))
+
+    def __sub__(self, other):
+        if not issubclass(ZData, other):
+            raise TypeError('can only subtract ZData types')
+
+        value = self.int - other.int
+        if type(other) == ZWord:
+            return ZWord(self._trunc_int(3, 2, value))
+        elif type(other) == ZByte:
+            return ZByte(self._trunc_int(2, 1, value))
+
+    def __mul__(self, other):
+        if not issubclass(ZData, other):
+            raise TypeError('can only multiply ZData types')
+
+        value = self.int * other.int
+        if type(other) == ZWord:
+            return ZWord(self._trunc_int(4, 2, value))
+        elif type(other) == ZByte:
+            return ZByte(self._trunc_int(2, 1, value))
+
+    def __floordiv__(self, other):
+        if not issubclass(ZData, other):
+            raise TypeError('can only divide ZData types')
+
+        value = self.int // other.int
+        if type(other) == ZWord:
+            return ZWord(self._trunc_int(4, 2, value))
+        elif type(other) == ZByte:
+            return ZByte(self._trunc_int(2, 1, value))
+
+    def __lshift__(self, other):
+        if (type(other) != int) or (other < 0):
+            raise TypeError('Can only shift by a positive integer')
+
+        value = self.int << other
+        return ZByte(self._trunc_int(2, 1, value))
+
+    def __rshift__(self, other):
+        if (type(other) != int) or (other < 0):
+            raise TypeError('Can only shift by a positive integer')
+
+        value = self.int >> other
+        return ZByte(self._trunc_int(2, 1, value))
+
+    def __and__(self, other):
+        if (type(other) != int) or (0 > other > 255):
+            raise TypeError('Can only apply bitwise operations with an integer between 0 and 255')
+
+        value = self.int & other
+        return ZByte(self._trunc_int(1, 1, value))
+
+    def __or__(self, other):
+        if (type(other) != int) or (0 > other > 255):
+            raise TypeError('Can only apply bitwise operations with an integer between 0 and 255')
+
+        value = self.int | other
+        return ZByte(self._trunc_int(1, 1, value))
+
+    def __invert__(self):
+        value = ~self.int
+        return ZByte(self._trunc_int(1, 1, value))
+
+    @staticmethod
+    def from_int(value: int):
+        if -128 < value > 127:
+            raise TypeError('Can only create a signed byte from a value between -128 and 127')
+
+        return ZByte(value.to_bytes(1, 'big', signed=True))
+
+    @staticmethod
+    def from_unsigned_int(value: int):
+        if 0 < value > 255:
+            raise TypeError('Can only create an unsigned byte from a value between 0 and 255')
+
+        return ZByte(value.to_bytes(1, 'big', signed=False))
+
+    def inc(self, amount: int = 1):
+        new_val = self.unsigned_int + amount
+
+        # Convert to 2 byte value to allow for over/underflow
+        bytes_val = new_val.to_bytes(2, 'big', signed=False)
+        return ZWord(bytes_val[1:])
+
+    def dec(self, amount: int = 1):
+        new_val = self.unsigned_int - amount
+
+        # Convert to 2 byte value to allow for over/underflow
+        bytes_val = new_val.to_bytes(2, 'big', signed=False)
+        return ZWord(bytes_val[1:])
+
+    def write(self, memory: memoryview, address: int):
+        memory[address:address+1] = self._value
+
+    @staticmethod
+    def read(memory: Union[bytes, memoryview], address: int) -> ZData:
+        return ZByte(memory[address:address+1])
+
+    def is_bit_set(self, bit_number: int) -> bool:
+        if 0 < bit_number > 7:
+            raise ValueError('Can only test bits 0-8 in a ZByte')
+
+        mask = 1 << bit_number
+        return (self.int & mask) != 0
+
+
+class ZWord(ZData):
+
+    def __init__(self, value: Union[bytes, memoryview]):
+        if type(value) == memoryview:
+            value = bytes(value)
+        elif type(value) != bytes:
+            raise TypeError('ZWord value can only be set with bytes or memoryview')
+
+        if len(value) != 2:
+            raise TypeError('only two bytes can be assigned to a ZWord')
+
+        super().__init__(value)
+
+    def _trunc_int(self, value: int):
+        bytes_val = value.to_bytes(4, 'big', signed=True)
+        return bytes_val[2:]
+
+    def __add__(self, other):
+        if not issubclass(ZData, other.__type__):
+            raise ValueError('Can only add to another ZData type')
+
+        value = self.int + other.int
+        return ZWord(self._trunc_int(value))
+
+    def __sub__(self, other):
+        if not issubclass(ZData, other.__type__):
+            raise ValueError('Can only subtract from another ZData type')
+
+        value = self.int - other.int
+        return ZWord(self._trunc_int(value))
+
+    def __mul__(self, other):
+        if not issubclass(ZData, other.__type__):
+            raise ValueError('Can only multiply with another ZData type')
+
+        value = self.int * other.int
+        return ZWord(self._trunc_int(value))
+
+    def __floordiv__(self, other):
+        if not issubclass(ZData, other.__type__):
+            raise ValueError('Can only divide by another ZData type')
+
+        value = self.int // other.int
+        return ZWord(self._trunc_int(value))
+
+    def __lshift__(self, other):
+        if (type(other) != int) or (other < 0):
+            raise ValueError('Can only shift by an unsigned int greater than 0')
+
+        value = self.int << other
+        return ZWord(self._trunc_int(value))
+
+    def __rshift__(self, other):
+        if (type(other) != int) or (other < 0):
+            raise ValueError('Can only shift by an unsigned int greater than 0')
+
+        value = self.int >> other
+        return ZWord.from_int(value)
+
+    def __and__(self, other):
+        if (type(other) != int) or (0 > other > 65535):
+            raise TypeError('Can only apply bitwise operations with an integer between 0 and 65535')
+
+        value = self.int & other
+        return ZWord.from_int(value)
+
+    def __or__(self, other):
+        if (type(other) != int) or (0 > other > 65535):
+            raise TypeError('Can only apply bitwise operations with an integer between 0 and 65535')
+
+        value = self.int | other
+        return ZWord.from_int(value)
+
+    def __invert__(self):
+        value = ~self.int
+        return ZWord.from_int(value)
+
+    @staticmethod
+    def from_int(value: int):
+        if -32768 < value > 32767:
+            raise TypeError('Can only create a ZWord from a value between -32768 and 32767')
+
+        return ZWord(value.to_bytes(2, 'big', signed=True))
+
+    @staticmethod
+    def from_unsigned_int(value: int):
+        if 0 < value > 65535:
+            raise TypeError('Can only create a ZWord from a value between 0 and 65535')
+
+        return ZWord(value.to_bytes(2, 'big', signed=False))
+
+    def inc(self, amount: int = 1):
+        new_val = self.unsigned_int + amount
+
+        # Convert to 3 byte value to allow for over/underflow
+        bytes_val = new_val.to_bytes(3, 'big', signed=False)
+        return ZWord(bytes_val[1:])
+
+    def dec(self, amount: int = 1):
+        new_val = self.unsigned_int - amount
+
+        # Convert to 3 byte value to allow for over/underflow
+        bytes_val = new_val.to_bytes(3, 'big', signed=False)
+        return ZWord(bytes_val[1:])
+
+    def write(self, memory: memoryview, address: int):
+        memory[address:address+2] = self._value
+
+    @staticmethod
+    def read(memory: Union[bytes, memoryview], address: int):
+        return ZWord(memory[address:address+2])
+
+    def is_bit_set(self, bit_number: int) -> bool:
+        if 0 < bit_number > 15:
+            raise ValueError('Can only test bits 0-15 in a ZByte')
+
+        mask = 1 << bit_number
+        return (self.int & mask) != 0
+
+
+


### PR DESCRIPTION
Created ZByte and ZWord data structures.

These will be used to replace most of the functionality of the `util` module which contained a bunch of rag-tag utility functions for accessing data at the word/byte/bit level. These classes will contain all functionality needed to go between Python and the bit-by-bit world of the ZMachine.

Closes #14 