### PR TITLE
Refactor screen interface to adhere to V3 spec

### DIFF
--- a/tests/dictionary_test.py
+++ b/tests/dictionary_test.py
@@ -33,21 +33,6 @@ def test_word_lookup_v3_leaves_bug(zork_v3_dict: ZMachineDictionary):
     assert word_addr == zork_v3_dict.entry_addr(348)
 
 
-@pytest.mark.skip('it seems all words are properly encoded')
-def test_all_word_encoding(zork_v3_dict: ZMachineDictionary):
-    wrong_words = dict()
-    for i in range(1, zork_v3_dict.number_of_entries+1):
-        addr = zork_v3_dict.entry_addr(i)
-        entry = zork_v3_dict.entry_at(addr)
-        expected_z_string = z_string(entry.text, zork_v3_dict.encoded_text_len)
-        if entry.encoded_text != expected_z_string:
-            wrong_words[i] = dict(text=entry.text,
-                                  found_z_string=entry.encoded_text.hex(),
-                                  expected_z_string=expected_z_string.hex())
-
-    assert wrong_words == {}
-
-
 word_lookup_test_cases_v3 = [
     ('zzmgck', 697, 'Finds last word'),
     ('zorkmi', 696, 'Second-to-last word'),

--- a/tests/interpreter_test.py
+++ b/tests/interpreter_test.py
@@ -5,7 +5,7 @@ from os import path
 from typing import Tuple
 
 from mocks import MockInput, MockScreen
-from zfun import ZCodeHeader, ZMachineInterpreter, ZMachineInterpreterV3, get_header, ZMachineVariables, ZMachineObjectTable, ZMachineStack, ZMachineRuntimeException
+from zfun import ZCodeHeader, ZMachineInterpreter, ZMachineInterpreterV3, get_header, ZMachineVariables, ZMachineObjectTable, ZMachineStack, ZMachineExitException
 
 
 def compare_machine_state(interpreter: ZMachineInterpreter, state_data_dir: str, num_objects: int = 250) -> dict:
@@ -131,7 +131,7 @@ def v3_header_and_data(zork1_v3_data: memoryview) -> Tuple[ZCodeHeader, memoryvi
 def test_playing_some_zork_v3(v3_header_and_data: Tuple[ZCodeHeader, memoryview]):
     header, memory = v3_header_and_data
     screen = MockScreen()
-    input = MockInput(['open mailbox', 'get leaflet', 'read leaflet', 'w'])
+    input = MockInput(['open mailbox', 'get leaflet', 'read leaflet', 'w', 'q', 'y'])
 
     interpreter = ZMachineInterpreterV3(header, memory, screen, input)
     interpreter.initialize()
@@ -139,9 +139,9 @@ def test_playing_some_zork_v3(v3_header_and_data: Tuple[ZCodeHeader, memoryview]
     try:
         interpreter.run()
         raise AssertionError('End of input should have occurred.')
-    except ZMachineRuntimeException as e:
+    except ZMachineExitException:
         # check message
-        assert interpreter.pc == 0x5910
+        assert interpreter.pc == 0x6e08
         text = ''.join(screen.printed_text)
         assert text == """ZORK I: The Great Underground Empire
 Copyright (c) 1981, 1982, 1983 Infocom, Inc. All rights reserved.
@@ -164,7 +164,9 @@ ZORK is a game of adventure, danger, and low cunning. In it you will explore som
 >Forest
 This is a forest, with trees in all directions. To the east, there appears to be sunlight.
 
->"""
+>Your score is 0 (total of 350 points), in 4 moves.
+This gives you the rank of Adventurer.
+Do you wish to leave the game? (Y is affirmative): >"""
 
 
 @pytest.mark.skip('only useful with data from other z-machine')

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -6,7 +6,6 @@ class MockScreen(ZMachineScreen):
 
     def __init__(self):
         self._printed_data: List[str] = []
-        self._is_status_displayed = False
 
     def initialize(self, interpreter: ZMachineInterpreter):
         interpreter.header.is_status_line_unavailable = True
@@ -20,7 +19,7 @@ class MockScreen(ZMachineScreen):
 
     @property
     def upper_window_height(self) -> int:
-        return 10
+        return 0
 
     @property
     def selected_window(self) -> int:
@@ -28,14 +27,6 @@ class MockScreen(ZMachineScreen):
 
     def print(self, text: str):
         self._printed_data.append(text)
-
-    @property
-    def is_status_displayed(self) -> bool:
-        return self._is_status_displayed
-
-    @is_status_displayed.setter
-    def is_status_displayed(self, displayed: bool):
-        self._is_status_displayed = displayed
 
     @property
     def printed_text(self) -> List[str]:

--- a/zfun/interpreter.py
+++ b/zfun/interpreter.py
@@ -723,7 +723,7 @@ class ZMachineInterpreterV3(ZMachineInterpreter):
         self._stack.pop()
 
     def _opcode__show_status(self):
-        self._screen.is_status_displayed = True
+        self._screen.update_status()
 
     def _opcode__verify(self):
         # Technically supposed to verify the integrity of the game file, but not doing it

--- a/zfun/screen.py
+++ b/zfun/screen.py
@@ -75,15 +75,11 @@ class ZMachineScreen(ABC):
         """
         pass
 
-    @property
-    @abstractmethod
-    def is_status_displayed(self) -> bool:
-        """ Should the status bar be displayed? """
-        pass
+    def update_status(self):
+        """ Manually update the status line.
 
-    @is_status_displayed.setter
-    @abstractmethod
-    def is_status_displayed(self, display_status: bool):
+        Note: This is only for V3 interpreters and in most cases probably does't need to be overridden.
+        """
         pass
 
 


### PR DESCRIPTION
Added  fully functioning curses screen/input implementation to the `tests` directory. Once this library is complete the curses screen/input combo will be put in its own project taking a dependency on `zfun`.

Closes #23 